### PR TITLE
Standardize fonts and sizes on home page

### DIFF
--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -1,7 +1,7 @@
 .button {
   color: white;
   border: none;
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1.25rem;
   background: rgba(205, 35, 49, 1);
   font-size: 1rem;
   cursor: pointer;

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -61,6 +61,10 @@ nav {
       background-color: rgba(224, 224, 224, 1);
     }
   }
+
+  & > a#become-member {
+    font-weight: 500;
+  }
 }
 
 .nav-links-wrapper:global(.open) {
@@ -102,6 +106,8 @@ nav {
     & > a#become-member {
       position: absolute;
       right: 1rem;
+      font-size: 0.875rem;
+      font-weight: 500;
     }
   }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,9 @@ const { title } = Astro.props;
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   </head>
   <body>
     <Nav client:load />
@@ -33,6 +36,7 @@ const { title } = Astro.props;
 <style is:global>
   * {
     box-sizing: border-box;
+    font-family: "Inter", sans-serif;
   }
 
   body {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,7 +18,7 @@ import Button from "../components/Button";
       <h1>Celebrating 10 years of <br /><strong>Cork Climbing</strong></h1>
       <JoinButton>Join us</JoinButton>
     </div>
-    <div style="padding: 2rem; font-weight: bold;">
+    <div style="padding: 2rem;">
       If you're interested in Outdoor Climbing we are the club for you
     </div>
     <!-- <div class="events">
@@ -36,7 +36,7 @@ import Button from "../components/Button";
         src={Holds}
         alt="Three Climbing holds. First is blue, second is white, last is orange"
       />
-      <div>
+      <div class="questions-content">
         <h2>About the Club</h2>
         <p>
           Established in 2015 Cork Climbing Club brings together all who are interested in the rock climbing scene in Ireland. Including bouldering, traditional and sports climbing. We promote the sport locally, develop international relations and organise climbing activities. You can find us at Awesome Walls Cork in Bishopstown, where we meet regularly Monday and Wednesday evenings.
@@ -68,13 +68,24 @@ import Button from "../components/Button";
     padding: 4rem;
   }
 
+  .questions-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
   .questions p {
     font-size: 1rem;
+  }
+
+  .questions-content a {
+    align-self: center;
   }
 
   .questions p,
   .questions h2 {
     text-align: left;
+    margin: 0;
   }
 
   @media (min-width: 800px) {
@@ -82,6 +93,10 @@ import Button from "../components/Button";
       display: flex;
       justify-content: center;
       gap: 2rem;
+    }
+
+    .questions-content a {
+      align-self: flex-start;
     }
 
     .questions > div {
@@ -107,6 +122,11 @@ import Button from "../components/Button";
   h1 {
     margin: 0;
     color: white;
+    font-weight: 600;
+  }
+
+  h2 {
+    font-weight: 600;
   }
 
   h1 strong {


### PR DESCRIPTION
The idea is to progress into standardizing the fonts and sizes used on the website.

I added the font suggested by Donal in the mock-ups : https://www.figma.com/design/56HAH1PLqtjs1IfGZWNint/Biodiversity-Business?node-id=655-669&node-type=frame&t=Q4WsOk8OKpcxpHa5-0

I also updated a bit the "About us" layout so that it looks more like the mock-up

Before :

![image](https://github.com/user-attachments/assets/9a36b8f4-3885-45bb-a76e-dafdcc41238d)

After :

![image](https://github.com/user-attachments/assets/7eaaeba1-9ba5-4f38-8798-27b42f3b4cc0)

